### PR TITLE
fix: use fork of react-syntax-highlighter to fix code display issue

### DIFF
--- a/src/main/java/com/flowingcode/vaadin/addons/syntaxhighlighter/SyntaxHighlighter.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/syntaxhighlighter/SyntaxHighlighter.java
@@ -31,7 +31,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * @since 1.0.0
  */
 @SuppressWarnings("serial")
-@NpmPackage(value = "react-syntax-highlighter", version = "15.5.0")
+@NpmPackage(value = "react-syntax-highlighter", version = "npm:@fengkx/react-syntax-highlighter@15.6.1")
 @JsModule("./react-syntax-highlighter.tsx")
 @Tag("syntax-highlighter")
 public class SyntaxHighlighter extends BaseSyntaxHighlighter {

--- a/src/main/java/com/flowingcode/vaadin/addons/syntaxhighlighter/SyntaxHighlighterPrism.java
+++ b/src/main/java/com/flowingcode/vaadin/addons/syntaxhighlighter/SyntaxHighlighterPrism.java
@@ -32,7 +32,7 @@ import com.vaadin.flow.component.dependency.NpmPackage;
  * @since 1.0.0
  */
 @SuppressWarnings("serial")
-@NpmPackage(value = "react-syntax-highlighter", version = "15.5.0")
+@NpmPackage(value = "react-syntax-highlighter", version = "npm:@fengkx/react-syntax-highlighter@15.6.1")
 @JsModule("./react-syntax-highlighter-prism.tsx")
 @Tag("syntax-highlighter-prism")
 public class SyntaxHighlighterPrism extends BaseSyntaxHighlighter {


### PR DESCRIPTION
Use a fork of the react component, as suggested in here: https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/513#issuecomment-1624434486 Fixes #2